### PR TITLE
Ability to override certain IP addresses

### DIFF
--- a/src/Buonzz/GeoIP/GeoIP.php
+++ b/src/Buonzz/GeoIP/GeoIP.php
@@ -28,7 +28,11 @@ class GeoIP{
   */
   public function __construct(){
       if(isset($_SERVER['REMOTE_ADDR']))
-          $this->ip = $_SERVER['REMOTE_ADDR'];     
+          $this->ip = $_SERVER['REMOTE_ADDR'];
+          
+      // Check if an override for the current ip exists
+      $overrides = \Config::get('laravel-4-freegeoip::overrides');
+      if(isset($this->ip, $overrides))$this->ip = $overrides[$this->ip];
   }
 
   /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -6,4 +6,10 @@ return array(
 	
 	// Timeout when calling the API (in seconds)
 	'timeout' => 30,
+	
+	// IP address overrides. Defaults localhost to Google
+	'overrides' => array(
+	  '127.0.0.1' => '64.233.160.0',
+	  'localhost' => '64.233.160.0',
+	)
 );


### PR DESCRIPTION
CAn override IP addresses, for example have local environment point to certain IP addresses instead of failing with 127.0.0.1
